### PR TITLE
Fix project name for core in documentation.

### DIFF
--- a/patchfile.drush.inc
+++ b/patchfile.drush.inc
@@ -31,7 +31,7 @@ function patchfile_drush_command() {
   $items['patch-project'] = array(
     'description' => 'Apply all the patches for a specific project as listed in the patch file.',
     'arguments' => array(
-      'project-name' => 'The name of the module, theme, profile, or \'core\' to re-apply patches to.',
+      'project-name' => 'The name of the module, theme, profile, or \'drupal\' to re-apply patches to.',
       'project-directory' => 'Optional, the directory of the project to use for the patches.',
     ),
     'required-arguments' => 1,
@@ -44,7 +44,7 @@ function patchfile_drush_command() {
   $items['patch-add'] = array(
     'description' => 'Add a new patch to the patch file.',
     'arguments' => array(
-      'project-name' => 'The name of the module, theme, profile, or \'core\' to re-apply patches to.',
+      'project-name' => 'The name of the module, theme, profile, or \'drupal\' to re-apply patches to.',
       'patch-file' => 'The path to the patch to apply. Can be an external URL.',
     ),
     'required-arguments' => TRUE,


### PR DESCRIPTION
"core" didn't work for me; I had to use "drupal".

Thanks for the awesome utility!