### PR TITLE
Fixed error when $options['patch-file'] defined and patch file absent

### DIFF
--- a/patchfile.drush.inc
+++ b/patchfile.drush.inc
@@ -275,7 +275,7 @@ function drush_patchfile_get_patched_projects($patchfile = NULL, $use_cache = FA
     $patchfile = drush_get_option('patch-file');
   }
 
-  if (!empty($patchfile)) {
+  if (!empty($patchfile) && file_exists($patchfile)) {
     // Cache not only by filename, but also by the time the file was modified
     // so that a drush cache clear is not necessary to pick up changes.
     $cid = _drush_patchfile_get_file_cid($patchfile);


### PR DESCRIPTION
For example, we have global patchfile location defined in `/etc/drush/drushrc.php`:
``` php
$options['patch-file'] = 'sites/default/patches/_list.make';
```

With this option sites without patchfile throws error on any `drush pm-download` command.